### PR TITLE
Cron alerts

### DIFF
--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -6,8 +6,8 @@
         <screen location="component://webroot/screen/webroot.xml">
             <subscreens-item name="jsmstatic" menu-include="false" location="component://ServiceJobMonitor/screen/sjmstatic.xml"/>
         </screen>
-        <screen location="component://webroot/screen/webroot/apps.xml">
-            <subscreens-item name="monitor" menu-title="Service Job Monitor" menu-index="15"
+        <screen location="component://tools/screen/System.xml">
+            <subscreens-item name="monitor" menu-title="Service Job Monitor" menu-index="13"
                              location="component://ServiceJobMonitor/screen/MonitorAdmin.xml"/>
         </screen>
     </screen-facade>

--- a/data/ServiceJobMonitorDemoData.xml
+++ b/data/ServiceJobMonitorDemoData.xml
@@ -7,7 +7,7 @@
                                   cronExpression="0 */5 * ? * *" paused="N"
                                   expireLockTime="3"
     >
-        <parameters parameterName="query" parameterValue="SELECT ORDER_ID FROM ORDER_HEADER WHERE LAST_UPDATED_STAMP &lt; {FROM} AND LAST_UPDATED_STAMP &gt; {THRU}"/>
+        <parameters parameterName="query" parameterValue="SELECT ORDER_ID FROM ORDER_HEADER WHERE LAST_UPDATED_STAMP &gt; {FROM} AND LAST_UPDATED_STAMP &lt; {THRU}"/>
     </moqui.service.job.ServiceJob>
 
     <tailorsoft.service.job.ServiceJobMonitor

--- a/data/ServiceJobMonitorDemoData.xml
+++ b/data/ServiceJobMonitorDemoData.xml
@@ -7,7 +7,7 @@
                                   cronExpression="0 */5 * ? * *" paused="N"
                                   expireLockTime="3"
     >
-        <parameters parameterName="query" parameterValue="SELECT ORDER_ID FROM ORDER_HEADER WHERE LAST_UPDATED_STAMP &lt; {FROM} AND LAST_UPDATE_STAMP &gt; {THRU}"/>
+        <parameters parameterName="query" parameterValue="SELECT ORDER_ID FROM ORDER_HEADER WHERE LAST_UPDATED_STAMP &lt; {FROM} AND LAST_UPDATED_STAMP &gt; {THRU}"/>
     </moqui.service.job.ServiceJob>
 
     <tailorsoft.service.job.ServiceJobMonitor

--- a/data/ServiceJobMonitorDemoData.xml
+++ b/data/ServiceJobMonitorDemoData.xml
@@ -1,6 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <entity-facade-xml type="demo">
+    <moqui.service.job.ServiceJob jobId="run_query" jobName="run_query"
+                                  description="Executes a SQL query"
+                                  serviceName="tailorsoft.monitor.MonitorServices.get#QueryFromLastJobRun"
+                                  cronExpression="0 */5 * ? * *" paused="N"
+                                  expireLockTime="3"
+    >
+        <parameters parameterName="query" parameterValue="SELECT ORDER_ID FROM ORDER_HEADER WHERE LAST_UPDATED_STAMP &lt; {FROM} AND LAST_UPDATE_STAMP &gt; {THRU}"/>
+    </moqui.service.job.ServiceJob>
+
+    <tailorsoft.service.job.ServiceJobMonitor
+            monitorId="run_query"
+            jobName="run_query"
+            title="SQL job"
+            valuePath="count"
+            indexName="sqlcount"
+            algorithmEnumId="ALGO_BOUNDS"
+            statusId="MonitorActive"
+    />
+
+    <tailorsoft.service.job.ServiceJobMonitorBounds
+            monitorId="run_query"
+            lower="0"
+            upper="0"
+            count="1"
+    />
+
     <!--  Temperature Example   -->
     <moqui.service.job.ServiceJob jobId="poll_temperature" jobName="poll_temperature"
                                   description="get temperature salt lake city"

--- a/data/ServiceJobMonitorDemoData.xml
+++ b/data/ServiceJobMonitorDemoData.xml
@@ -14,7 +14,7 @@
             monitorId="run_query"
             jobName="run_query"
             title="SQL job"
-            valuePath="count"
+            valuePath="results.count"
             indexName="sqlcount"
             algorithmEnumId="ALGO_BOUNDS"
             statusId="MonitorActive"

--- a/entity/ServiceJobMonitor.xml
+++ b/entity/ServiceJobMonitor.xml
@@ -51,6 +51,7 @@
         <field name="lower" type="number-float"/>
         <field name="upper" type="number-float"/>
         <field name="count" type="number-integer"/>
+        <field name="cron" type="text-short"/>
         <relationship type="one" related="tailorsoft.service.job.ServiceJobMonitor"/>
     </entity>
 

--- a/screen/MonitorAdmin.xml
+++ b/screen/MonitorAdmin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/xml-screen-2.1.xsd" require-authentication="true"
-        menu-image="glyphicon glyphicon-flash"
+        menu-image="glyphicon glyphicon-hdd"
         menu-image-type="icon">
 
 

--- a/screen/MonitorAdmin.xml
+++ b/screen/MonitorAdmin.xml
@@ -14,7 +14,7 @@
                     <link href="/jsmstatic/css/style.css" />
                     <script src="https://cdn.jsdelivr.net/npm/vega@5.9.0"></script>
                     <script src="https://cdn.jsdelivr.net/npm/vega-lite@4.0.0"></script>
-                    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.2.0"></script>
+                    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.2.2/build/vega-embed.js"></script>
                     <script src="/jsmstatic/js/main.js"></script>
                     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"/>
                 ]]>

--- a/screen/sjmstatic/js/main.js
+++ b/screen/sjmstatic/js/main.js
@@ -42,6 +42,17 @@ function generateBox({ name, type = "", title = "" }) {
 
 const container = document.getElementById("chartsContainer");
 
+function mouseHandler(handler, event, item, value) {
+  if(item && event.vegaType == 'mousemove') {
+    if(item.datum && item.datum.hasLink == null && item.datum.jobRunId){
+      item.datum.hasLink = true;
+      $(item._svg).on('click', function () {
+        window.location = "/vapps/system/ServiceJob/JobRuns/JobRunDetail?jobRunId="+item.datum.jobRunId
+      })
+    }
+  }
+}
+
 function renderVega(data, elementId) {
   const isOpenAlert =
     data.alerts.filter(alert => {
@@ -58,6 +69,7 @@ function renderVega(data, elementId) {
   });
 
   const el = document.getElementById(elementId);
+  console.log(data)
 
   const layer = [
     {
@@ -125,8 +137,7 @@ function renderVega(data, elementId) {
         type: "point",
         filled: true,
         cursor: "pointer",
-        size: 80,
-        href: data.jobRunId == null ? "#" : "/vapps/system/ServiceJob/JobRuns/JobRunDetail?jobRunId=" + data.jobRunId
+        size: 80
       },
       encoding: {
         color: {
@@ -249,8 +260,12 @@ function renderVega(data, elementId) {
       }
     }
   };
+  const VeOptions = {
+    tooltip: mouseHandler,
+    actions: false,
+    renderer: "svg" };
 
-  vegaEmbed("#" + elementId, yourVlSpec, { actions: false, renderer: "svg" });
+  vegaEmbed("#" + elementId, yourVlSpec, VeOptions);
 }
 
 function makeChart(data) {

--- a/screen/sjmstatic/js/main.js
+++ b/screen/sjmstatic/js/main.js
@@ -126,7 +126,7 @@ function renderVega(data, elementId) {
         filled: true,
         cursor: "pointer",
         size: 80,
-        href: "/vapps/monitor/Monitor?monitorId=" + data.monitorId
+        href: data.jobRunId == null ? "#" : "/vapps/system/ServiceJob/JobRuns/JobRunDetail?jobRunId=" + data.jobRunId
       },
       encoding: {
         color: {

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -508,4 +508,49 @@ along with this software (see the LICENSE.md file). If not, see
             </script>
         </actions>
     </service>
+
+<!--    Validate false, as with true it filters out HTML elements such as < and > -->
+    <service verb="get" noun="QueryResults" authenticate="true" validate="false">
+        <in-parameters>
+            <parameter name="groupName" default="transactional" />
+            <parameter name="startDate" type="Timestamp" />
+            <parameter name="endDate" type="Timestamp" />
+            <parameter name="query" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="result" type="Integer" />
+        </out-parameters>
+        <actions>
+            <script><![CDATA[
+                import java.sql.Connection
+                import org.moqui.context.ExecutionContext
+
+                ExecutionContext ec = context.ec
+                Connection con = ec.getEntity().getConnection(groupName)
+                def statement = con.createStatement()
+
+                //Create a timestamp literal http://www.h2database.com/html/grammar.html#timestamp
+                query = query.replace("{FROM}",
+                                "TIMESTAMP '" + startDate.toString()+"'")
+                            .replace("{THRU}",
+                                "TIMESTAMP '" + endDate.toString()+"'")
+
+                def results = statement.executeQuery(query)
+
+                //The cursor starts before the first row
+                if(!results.next())
+                    throw new Exception("No values returned")
+
+                def meta = results.getMetaData()
+                if (meta.getColumnCount() > 1)
+                    throw new Exception("More than 1 column returned, 1 expected")
+
+                // get the first column, which we expect to be an int.
+                result = results.getInt(1);
+
+                statement.close()
+                con.close()
+                ]]></script>
+        </actions>
+    </service>
 </services>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -509,6 +509,23 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
+    <service verb="get" noun="QueryFromLastJobRun" authenticate="anonymous-all" validate="false">
+        <in-parameters>
+            <parameter name="query" required="true" />
+            <parameter name="jobRunId"/>
+            <parameter name="lastRunTime"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="results" />
+        </out-parameters>
+        <actions>
+            <service-call name="tailorsoft.monitor.MonitorServices.get#QueryResults"
+                          in-map="[startDate:lastRunTime.startTime, endDate:ec.user.nowTimestamp, query:query]"
+                          out-map="results"
+            />
+        </actions>
+    </service>
+
 <!--    Validate false, as with true it filters out HTML elements such as < and > -->
     <service verb="get" noun="QueryResults" authenticate="true" validate="false">
         <in-parameters>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -509,7 +509,7 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
-    <service verb="get" noun="QueryFromLastJobRun" authenticate="anonymous-all">
+    <service verb="get" noun="QueryFromLastJobRun" authenticate="anonymous-all" validate="false">
         <in-parameters>
             <parameter name="query" required="true" />
             <parameter name="lastRunTime" type="Timestamp"/>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -52,7 +52,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <set field="jsonResults" from="jsonResults[part]"/>
             </iterate>
 
-            <if condition="!jsonResults || !jsonResults.toString().isNumber()">
+            <if condition="jsonResults.toString() != '0' &amp;&amp; (!jsonResults || !jsonResults.toString().isNumber())">
                 <return error="true" message="'${jsonResults.toString()}' is not a valid result found in Job ${monitor.jobName} for Monitor ${monitor.monitorId}"/>
             </if>
 

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -112,7 +112,44 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
-    <!--  search Elasticsearch data  -->
+    <service verb="send" noun="Notification">
+        <in-parameters>
+            <parameter name="jobName"/>
+            <parameter name="monitorId"/>
+            <parameter name="jobRunId"/>
+            <parameter name="value"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="notificationId"/>
+        </out-parameters>
+        <actions>
+            <script><![CDATA[
+                Map notificationData = [
+                        id              : jobRunId,
+                        jobName         : jobName,
+                        jobRunId        : jobRunId,
+                        monitorId       : monitorId,
+                        fromDate        : new Date(),
+                        value           : value,
+                        status          : 'open',
+                        lastUpdatedStamp: new Date(),
+                        from            : 'noreply@moqui.org'
+                ]
+
+                notificationId = ec
+                        .makeNotificationMessage()
+                        .topic(monitorId)
+                        .type("danger")
+                        .title("Alert Bounds")
+                        .message(notificationData)
+                        .userGroupId("ALL_USERS")
+                        .send()
+                        .getNotificationMessageId()
+                ]]></script>
+        </actions>
+    </service>
+
+    <!--  search Elasticsearch data -->
     <service verb="process" noun="DatapointBounds" authenticate="anonymous-all">
         <in-parameters>
             <parameter name="jobName"/>
@@ -125,158 +162,47 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="value"/>
         </out-parameters>
         <actions>
-            <log message="\n ======= bounds ${indexName}, ${value}, ${jobName}, ${context} ${monitorId} "/>
             <set field="messageData" from="[:]"/>
             <entity-find-one entity-name="tailorsoft.service.job.ServiceJobMonitorBounds" value-field="monitorBounds" cache="true">
                 <field-map field-name="monitorId"/>
             </entity-find-one>
-
+            <set field="alertCount" from="monitorBounds.count" />
             <entity-find entity-name="tailorsoft.service.job.ServiceJobMonitorAlert" list="alertList" limit="1">
                 <econdition field-name="monitorId" from="monitorId"/>
                 <order-by field-name="-fromDate"/>
             </entity-find>
 
-            <log message="\n ======= entity bounds: ${monitorBounds}"/>
+            <service-call name="tailorsoft.monitor.MonitorServices.get#IndexHits"
+                          in-map="['indexName':indexName, 'searchMap': ['sort':['@timestamp':'desc'], 'size':alertCount]]"
+                          out-map="indexHits"/>
+            <set field="hits" from="indexHits.hitList" />
 
-            <script>
-                <![CDATA[
-                import org.moqui.context.ExecutionContext
-                import javax.naming.directory.SearchControls
+            <if condition="hits.size() &lt; monitorBounds.count">
+                <return />
+            </if>
 
-                sleep(1200);
-
-                ExecutionContext ec = context.ec
-
-                String sendNotification(data) {
-                    logger.info("notification ${data}")
-
-                    Map notificationData = [
-                            id              : jobRunId,
-                            jobName         : jobName,
-                            jobRunId        : jobRunId,
-                            monitorId       : monitorId,
-                            fromDate        : new Date(),
-                            value           : value,
-                            status          : 'open',
-                            lastUpdatedStamp: new Date(),
-                            from            : 'noreply@moqui.org'
-                    ]
-                    notificationId = ec
-                            .makeNotificationMessage()
-                            .topic(monitorId)
-                            .type("danger")
-                            .title("Alert Bounds")
-                            .message(notificationData)
-                            .userGroupId("ALL_USERS")
-                            .send()
-                            .getNotificationMessageId()
-
-                    return notificationId
-                }
-
-                try {
-                    int alertCount = Integer.parseInt(monitorBounds.count.toString())
-
-
-                    // hits from elasticsearch
-                    Map searchMap = ["sort":["@timestamp":"desc"], "size":alertCount]
-                    indexHits = ec.service.sync().name("tailorsoft.monitor.MonitorServices.get#IndexHits").parameters(["indexName":indexName, "searchMap":searchMap]).call()
-                    hits = indexHits.hitList
-
-                    logger.info("\n ======== ES results")
-                    logger.info(hits.toString())
-
-                    Float upperBound = Float.parseFloat(monitorBounds.upper.toString())
-                    Float lowerBound = Float.parseFloat(monitorBounds.lower.toString())
-                    int boundsCount = Integer.parseInt(monitorBounds.count.toString());
-                    int size = hits.size();
-
-
-                    if (size < boundsCount) {
-                        // too few points to evaluate
-                        return false;
-                    }
-
-                    Boolean upperBoundAllValid = true;
-                    Boolean lowerBoundAllValid = true;
-
-                    for (int i = 0; i < size; i++) {
-                        Map hit = hits[i]._source
-                        Float value = Float.parseFloat(hit.value.toString())
-
-                        if (value < upperBound) {
-                            upperBoundAllValid = false;
-                        }
-
-                        if (value > lowerBound) {
-                            lowerBoundAllValid = false;
-                        }
-                    }
-
-                    logger.info('===== upper and lower bounds')
-                    logger.info(upperBoundAllValid.toString())
-                    logger.info(lowerBoundAllValid.toString())
-
-
-                    if (upperBoundAllValid || lowerBoundAllValid) {
-                        Map hit = hits[0]._source
-                        Float value = Float.parseFloat(hit.value.toString())
-
-                        if (alertList.size() > 0 && alertList[0].statusId.toString() == 'SjmOpen') {
-                            logger.info('=== last alert still open')
-                            // @todo do nothing
-                            return false;
-                        }
-
-                        notificationId = sendNotification([monitorId: monitorId, value: value]);
-
-                        ec.service.sync()
-                                .name("create#tailorsoft.service.job.ServiceJobMonitorAlert")
-                                .parameters([
-                                        id              : jobRunId,
-                                        monitorId       : monitorId,
-                                        jobName         : jobName,
-                                        jobRunId        : jobRunId,
-                                        fromDate        : new Date(),
-                                        value           : value,
-                                        statusId        : 'SjmOpen',
-                                        notification    : notificationId,
-                                        lastUpdatedStamp: new Date(),
-                                ])
-                                .call()
-                        logger.info('==== notification sent')
-
-                    }
-
-                    if (alertList.size() > 0 && alertList[0].statusId.toString() == 'SjmOpen') {
-                        currentAlert = alertList[0];
-
-                        Boolean restoreValid = true;
-
-                        for (int i = 0; i < size; i++) {
-                            Map hit = hits[i]._source
-                            Float value = Float.parseFloat(hit.value.toString())
-
-                            logger.info("alertId: ${currentAlert.id}- ${i.toString()} - ${value.toString()}")
-
-                            if (value > upperBound || value < lowerBound) {
-                                restoreValid = false;
-                            }
-                        }
-
-                        if (restoreValid) {
-
-                            ec.service.sync()
-                                    .name("update#tailorsoft.service.job.ServiceJobMonitorAlert")
-                                    .parameters([id: currentAlert.id, statusId: 'SjmClosed', thruDate: new Date()])
-                                    .call()
-                        }
-                    }
-                } finally {
-                    // TODO close client?
-                }
-                ]]>
-            </script>
+            <set field="outOfUpperBound" from="hits.every{it._source.value.toFloat() &gt; monitorBounds.upper}" />
+            <set field="outOfLowerBound" from="hits.every{it._source.value.toFloat() &lt; monitorBounds.lower}" />
+            <set field="isLastAlertOpen" from="alertList.size() > 0 &amp;&amp; alertList[0].statusId.toString() == 'SjmOpen'"/>
+            <if condition="isLastAlertOpen" >
+                <if condition="!outOfUpperBound &amp;&amp; !outOfLowerBound" >
+                    <set field="id" from="alertList[0].id" />
+                    <entity-find-one entity-name="tailorsoft.service.job.ServiceJobMonitorAlert" value-field="alert"/>
+                    <set field="alert.statusId" value="SjmClosed" />
+                    <set field="alert.thruDate" from="new Date()" />
+                    <entity-update value-field="alert"/>
+                </if>
+                <else>
+                    <if condition="outOfLowerBound || outOfUpperBound" >
+                        <service-call name="tailorsoft.monitor.MonitorServices.send#Notification" in-map="context" />
+                        <entity-make-value entity-name="ServiceJobMonitorAlert" value-field="alert"
+                                           map="['id': jobRunId, 'monitorId': monitorId, 'jobName': jobName, 'jobRunId': jobRunId,
+                                         'fromDate': new Date(), 'value': value, 'statusId': 'SjmOpen', 'notification': notificationId,
+                                         'lastUpdatedStamp': new Date()]"/>
+                        <entity-create value-field="alert" />
+                    </if>
+                </else>
+            </if>
         </actions>
     </service>
 
@@ -461,20 +387,20 @@ along with this software (see the LICENSE.md file). If not, see
             <script>
                 <![CDATA[
 
-                    client = ec.elastic.getDefault()
+                client = ec.elastic.getDefault()
 
-                    if (!client.indexExists(indexName)) {
-                        try {
-                            Map indexMapping = ["properties":["@timestamp":["type":"date"], "value":["type":"float"]]];
-                            client.createIndex(indexName, indexMapping, (String) null)
-                            result = "INDEX_CREATED"
-                        } catch (Exception e) {
-                            logger.error("Error checking and creating ${indexName} ES index", e)
-                            result = "INDEX_NOT_CREATED"
-                        }
-                    }else{
-                        result = "INDEX_ALREADY_EXIST"
+                if (!client.indexExists(indexName)) {
+                    try {
+                        Map indexMapping = ["properties":["@timestamp":["type":"date"], "value":["type":"float"]]];
+                        client.createIndex(indexName, indexMapping, (String) null)
+                        result = "INDEX_CREATED"
+                    } catch (Exception e) {
+                        logger.error("Error checking and creating ${indexName} ES index", e)
+                        result = "INDEX_NOT_CREATED"
                     }
+                }else{
+                    result = "INDEX_ALREADY_EXIST"
+                }
                 ]]>
             </script>
         </actions>
@@ -493,17 +419,17 @@ along with this software (see the LICENSE.md file). If not, see
             <script>
                 <![CDATA[
 
-                    client = ec.elastic.getDefault()
+                client = ec.elastic.getDefault()
 
-                    if (client.indexExists(indexName)) {
-                        try {
-                            hitList = client.searchHits(indexName, searchMap)
-                        } catch (Exception e) {
-                            logger.error("Can't find hits in the index: ${indexName}", e)
-                        }
-                    }else{
-                        logger.warn("Can't find index with name: ${indexName}", e)
+                if (client.indexExists(indexName)) {
+                    try {
+                        hitList = client.searchHits(indexName, searchMap)
+                    } catch (Exception e) {
+                        logger.error("Can't find hits in the index: ${indexName}", e)
                     }
+                }else{
+                    logger.warn("Can't find index with name: ${indexName}", e)
+                }
                 ]]>
             </script>
         </actions>
@@ -526,7 +452,7 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
-<!--    Validate false, as with true it filters out HTML elements such as < and > -->
+    <!--    Validate false, as with true it filters out HTML elements such as < and > -->
     <service verb="get" noun="QueryResults" authenticate="true" validate="false">
         <in-parameters>
             <parameter name="groupName" default="transactional" />

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -149,6 +149,28 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
+    <service verb="check" noun="InCronRange">
+        <in-parameters>
+            <parameter name="cron" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="valid" type="Boolean" />
+        </out-parameters>
+        <actions>
+            <script>
+                <![CDATA[
+                def exec = org.moqui.impl.service.ScheduledJobRunner.getExecutionTime(cron)
+                def now = java.time.ZonedDateTime.ofInstant(new Date().toInstant(), java.time.ZoneId.systemDefault())
+
+                def timeSinceLast = exec.timeFromLastExecution(now).get().toMinutes()
+                def timeToNext = exec.timeToNextExecution(now).get().toMinutes()
+
+                validTime = timeSinceLast < 60 && timeToNext < 60
+                ]]>
+            </script>
+        </actions>
+    </service>
+
     <!--  search Elasticsearch data -->
     <service verb="process" noun="DatapointBounds" authenticate="anonymous-all">
         <in-parameters>
@@ -194,12 +216,18 @@ along with this software (see the LICENSE.md file). If not, see
                 </if>
                 <else>
                     <if condition="outOfLowerBound || outOfUpperBound" >
-                        <service-call name="tailorsoft.monitor.MonitorServices.send#Notification" in-map="context" out-map="notificationId" />
-                        <log message="Created alert in monitor ${monitorId} with value ${value} from the job run id ${jobRunId} and notification ${notificationId.notificationId}" />
-                        <service-call name="create#tailorsoft.service.job.ServiceJobMonitorAlert"
-                                           in-map="['id': jobRunId, 'monitorId': monitorId, 'jobName': jobName, 'jobRunId': jobRunId,
-                                         'fromDate': new Date(), 'value': value, 'statusId': 'SjmOpen', 'notification': notificationId.notificationId,
+                        <set field="validTime" value="true" type="Boolean" />
+                        <if condition="monitorBounds.cron != null" >
+                            <service-call name="tailorsoft.monitor.MonitorServices.check#InCronRange" in-map="['cron': monitorBounds.cron]"  out-map="context" />
+                        </if>
+                        <if condition="validTime">
+                            <service-call name="tailorsoft.monitor.MonitorServices.send#Notification" in-map="context" out-map="context" />
+                            <log message="Created alert in monitor ${monitorId} with value ${value} from the job run id ${jobRunId} and notification ${notificationId}" />
+                            <service-call name="create#tailorsoft.service.job.ServiceJobMonitorAlert"
+                                          in-map="['id': jobRunId, 'monitorId': monitorId, 'jobName': jobName, 'jobRunId': jobRunId,
+                                         'fromDate': new Date(), 'value': value, 'statusId': 'SjmOpen', 'notification': notificationId,
                                          'lastUpdatedStamp': new Date()]"/>
+                        </if>
                     </if>
                 </else>
             </if>
@@ -239,9 +267,6 @@ along with this software (see the LICENSE.md file). If not, see
                 <econdition field-name="fromDate" operator="less" from="thruDateFormated"/>
             </entity-find>
 
-
-            <log message="============================== ${alertsList} ${fromDate} ${thruDate}"/>
-
             <script>
                  <![CDATA[
                 import org.moqui.context.ExecutionContext
@@ -250,10 +275,6 @@ along with this software (see the LICENSE.md file). If not, see
 
                 ExecutionContext ec = context.ec
                 client = ec.elastic.getDefault()
-
-                logger.info("=================")
-                logger.info(fromDate)
-                logger.info(thruDate)
 
                 SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -509,18 +509,17 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
-    <service verb="get" noun="QueryFromLastJobRun" authenticate="anonymous-all" validate="false">
+    <service verb="get" noun="QueryFromLastJobRun" authenticate="anonymous-all">
         <in-parameters>
             <parameter name="query" required="true" />
-            <parameter name="jobRunId"/>
-            <parameter name="lastRunTime"/>
+            <parameter name="lastRunTime" type="Timestamp"/>
         </in-parameters>
         <out-parameters>
             <parameter name="results" />
         </out-parameters>
         <actions>
             <service-call name="tailorsoft.monitor.MonitorServices.get#QueryResults"
-                          in-map="[startDate:lastRunTime.startTime, endDate:ec.user.nowTimestamp, query:query]"
+                          in-map="[startDate:lastRunTime, endDate:ec.user.nowTimestamp, query:query]"
                           out-map="results"
             />
         </actions>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -518,38 +518,43 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="query" required="true"/>
         </in-parameters>
         <out-parameters>
-            <parameter name="result" type="Integer" />
+            <parameter name="count" type="Integer"/>
+            <parameter name="result" type="List"/>
         </out-parameters>
         <actions>
+            <set field="count" from="0"/>
+            <set field="result" from="[]"/>
             <script><![CDATA[
                 import java.sql.Connection
                 import org.moqui.context.ExecutionContext
+
+                import java.util.logging.Logger
 
                 ExecutionContext ec = context.ec
                 Connection con = ec.getEntity().getConnection(groupName)
                 def statement = con.createStatement()
 
+                def logger = ec.getLogger()
+
                 //Create a timestamp literal http://www.h2database.com/html/grammar.html#timestamp
                 query = query.replace("{FROM}",
-                                "TIMESTAMP '" + startDate.toString()+"'")
-                            .replace("{THRU}",
-                                "TIMESTAMP '" + endDate.toString()+"'")
+                        "TIMESTAMP '" + startDate.toString() + "'")
+                        .replace("{THRU}",
+                                "TIMESTAMP '" + endDate.toString() + "'")
 
-                def results = statement.executeQuery(query)
+                def queryrs = statement.executeQuery(query)
 
-                //The cursor starts before the first row
-                if(!results.next())
-                    throw new Exception("No values returned")
+                def meta = queryrs.getMetaData()
+                def columns = meta.getColumnCount()
 
-                def meta = results.getMetaData()
-                if (meta.getColumnCount() > 1)
-                    throw new Exception("More than 1 column returned, 1 expected")
-
-                // get the first column, which we expect to be an int.
-                result = results.getInt(1);
-
-                statement.close()
-                con.close()
+                while (queryrs.next()) {
+                    Map<String, Object> row = new HashMap<>()
+                    for (int i = 1; i <= columns; ++i) {
+                        row.put(meta.getColumnName(i), queryrs.getObject(i))
+                    }
+                    count++
+                    result.add(row);
+                }
                 ]]></script>
         </actions>
     </service>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -194,12 +194,12 @@ along with this software (see the LICENSE.md file). If not, see
                 </if>
                 <else>
                     <if condition="outOfLowerBound || outOfUpperBound" >
-                        <service-call name="tailorsoft.monitor.MonitorServices.send#Notification" in-map="context" />
-                        <entity-make-value entity-name="ServiceJobMonitorAlert" value-field="alert"
-                                           map="['id': jobRunId, 'monitorId': monitorId, 'jobName': jobName, 'jobRunId': jobRunId,
-                                         'fromDate': new Date(), 'value': value, 'statusId': 'SjmOpen', 'notification': notificationId,
+                        <service-call name="tailorsoft.monitor.MonitorServices.send#Notification" in-map="context" out-map="notificationId" />
+                        <log message="Created alert in monitor ${monitorId} with value ${value} from the job run id ${jobRunId} and notification ${notificationId.notificationId}" />
+                        <service-call name="create#tailorsoft.service.job.ServiceJobMonitorAlert"
+                                           in-map="['id': jobRunId, 'monitorId': monitorId, 'jobName': jobName, 'jobRunId': jobRunId,
+                                         'fromDate': new Date(), 'value': value, 'statusId': 'SjmOpen', 'notification': notificationId.notificationId,
                                          'lastUpdatedStamp': new Date()]"/>
-                        <entity-create value-field="alert" />
                     </if>
                 </else>
             </if>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -20,7 +20,7 @@ along with this software (see the LICENSE.md file). If not, see
         <in-parameters>
             <parameter name="jobName" required="true"/>
             <parameter name="endTime" required="true"/>
-            <parameter name="jobName" required="true"/>
+            <parameter name="jobRunId" required="true"/>
             <parameter name="results" required="true"/>
         </in-parameters>
         <out-parameters>
@@ -68,7 +68,7 @@ along with this software (see the LICENSE.md file). If not, see
             <if condition="monitor.algorithmEnumId == 'ALGO_BOUNDS'">
                 <service-call
                         name="tailorsoft.monitor.MonitorServices.process#DatapointBounds"
-                        in-map="[indexName:monitor.indexName, value:doubleValue, date:endDate, jobName:jobName, jobRunId: jobRunId, monitorId: monitor.monitorId, ]"/>
+                        in-map="[indexName:monitor.indexName, value:doubleValue, date:endDate, jobName:jobName, jobRunId:jobRunId, monitorId: monitor.monitorId, ]"/>
             </if>
         </actions>
     </service>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -61,14 +61,15 @@ along with this software (see the LICENSE.md file). If not, see
                 <return error="true" message="No double value found at path: ${monitor.valuePath} in ${results} "/>
             </if>
 
-            <!-- store in elasticsearch -->
-            <service-call name="tailorsoft.monitor.MonitorServices.save#Datapoint"
-                          in-map="[date:endTime, value:doubleValue, indexName:monitor.indexName]"/>
-
             <if condition="monitor.algorithmEnumId == 'ALGO_BOUNDS'">
                 <service-call
                         name="tailorsoft.monitor.MonitorServices.process#DatapointBounds"
-                        in-map="[indexName:monitor.indexName, value:doubleValue, date:endDate, jobName:jobName, jobRunId:jobRunId, monitorId: monitor.monitorId, ]"/>
+                        in-map="[indexName:monitor.indexName, value:doubleValue, date:endDate, jobName:jobName, jobRunId:jobRunId, monitorId: monitor.monitorId]"/>
+
+                <!-- store in elasticsearch -->
+                <service-call name="tailorsoft.monitor.MonitorServices.save#Datapoint"
+                in-map="[date:endTime, value:doubleValue, indexName:monitor.indexName]"/>
+
             </if>
         </actions>
     </service>
@@ -178,7 +179,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="monitorId"/>
             <parameter name="jobRunId"/>
             <parameter name="indexName"/>
-            <parameter name="value"/>
+            <parameter name="value" type="Float"/>
         </in-parameters>
         <out-parameters>
             <parameter name="value"/>
@@ -188,7 +189,7 @@ along with this software (see the LICENSE.md file). If not, see
             <entity-find-one entity-name="tailorsoft.service.job.ServiceJobMonitorBounds" value-field="monitorBounds" cache="true">
                 <field-map field-name="monitorId"/>
             </entity-find-one>
-            <set field="alertCount" from="monitorBounds.count" />
+            <set field="alertCount" from="monitorBounds.count-1" />
             <entity-find entity-name="tailorsoft.service.job.ServiceJobMonitorAlert" list="alertList" limit="1">
                 <econdition field-name="monitorId" from="monitorId"/>
                 <order-by field-name="-fromDate"/>
@@ -197,16 +198,16 @@ along with this software (see the LICENSE.md file). If not, see
             <service-call name="tailorsoft.monitor.MonitorServices.get#IndexHits"
                           in-map="['indexName':indexName, 'searchMap': ['sort':['@timestamp':'desc'], 'size':alertCount]]"
                           out-map="indexHits"/>
-            <set field="hits" from="indexHits.hitList" />
+            <set field="hits" from="indexHits.hitList.collect{it._source.value.toFloat()}" />
+            <script>hits.push(value)</script>
 
             <if condition="hits.size() &lt; monitorBounds.count">
                 <return />
             </if>
 
-            <set field="outOfUpperBound" from="hits.every{it._source.value.toFloat() &gt; monitorBounds.upper}" />
-            <set field="outOfLowerBound" from="hits.every{it._source.value.toFloat() &lt; monitorBounds.lower}" />
-            <set field="isLastAlertOpen" from="alertList.size() > 0 &amp;&amp; alertList[0].statusId.toString() == 'SjmOpen'"/>
-            <if condition="isLastAlertOpen" >
+            <set field="outOfUpperBound" from="hits.every{it &gt; monitorBounds.upper.toFloat()}" />
+            <set field="outOfLowerBound" from="hits.every{it &lt; monitorBounds.lower.toFloat()}" />
+            <if condition="alertList.size() > 0 &amp;&amp; alertList[0].statusId.toString() == 'SjmOpen'" >
                 <if condition="!outOfUpperBound &amp;&amp; !outOfLowerBound" >
                     <set field="id" from="alertList[0].id" />
                     <entity-find-one entity-name="tailorsoft.service.job.ServiceJobMonitorAlert" value-field="alert"/>
@@ -355,7 +356,7 @@ along with this software (see the LICENSE.md file). If not, see
             <if condition="monitor.algorithmEnumId == 'ALGO_BOUNDS'">
                 <service-call
                         name="tailorsoft.monitor.MonitorServices.process#DatapointBounds"
-                        in-map="[indexName:monitor.indexName, value:doubleValue, date:endDate, monitorId: monitor.monitorId, ]"/>
+                        in-map="[indexName:monitor.indexName, value:doubleValue, date:endDate, monitorId: monitor.monitorId]"/>
             </if>
 
         </actions>

--- a/service/tailorsoft/monitor/MonitorServices.xml
+++ b/service/tailorsoft/monitor/MonitorServices.xml
@@ -518,6 +518,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="results" />
         </out-parameters>
         <actions>
+            <set field="lastRunTime" from="lastRunTime ? lastRunTime : ec.user.nowTimestamp" />
             <service-call name="tailorsoft.monitor.MonitorServices.get#QueryResults"
                           in-map="[startDate:lastRunTime, endDate:ec.user.nowTimestamp, query:query]"
                           out-map="results"


### PR DESCRIPTION
* Refactors process datapointbounds service
* Monitor bounds now have a cron field that specifies in a hourly run cron expression when alerts can be created (for example `0 0 7-16 ? * SUN,MON,TUE,WED,THU *` specifies alerts should only be created between 7-16 hours on workdays)
* Tooltips are now hidden
* Clicking on a mark with a jobrunid redirects to the information about that run